### PR TITLE
Fix Pillow 10 compatibility: replace removed textsize with textbbox

### DIFF
--- a/igibson/render_utils.py
+++ b/igibson/render_utils.py
@@ -398,7 +398,8 @@ def annotate_bbox(image, obj, bbox_vertices_uv, sim_env):
 
     label = obj_name_pddl
     font = ImageFont.load_default()
-    label_width, label_height = draw.textsize(label, font=font) # might be incorrect without with fontsize=100
+    bbox = draw.textbbox((0, 0), label, font=font)
+    label_width, label_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
 
     # Try rightmost point
     candidates = [


### PR DESCRIPTION
ImageDraw.textsize was removed in Pillow 10.0.0. Replace with textbbox which returns (left, top, right, bottom) bounding box.